### PR TITLE
feat: notify on a plugin update

### DIFF
--- a/pkg/core/scrapper.go
+++ b/pkg/core/scrapper.go
@@ -486,7 +486,7 @@ func (s *Scrapper) store(data *plugin.Plugin) error {
 		return err
 	}
 
-	log.Debug().Str("moduleName", data.Name).Msg("Updated")
+	log.Info().Str("moduleName", data.Name).Str("latestVersion", data.LatestVersion).Msg("Updated")
 
 	return nil
 }


### PR DESCRIPTION
Related to #7 

The purpose of this PR is to send logs to Datadog (without setting logs to debug) in order to send slack notification on a plugin update.