### PR TITLE
fix: notify pilot team only when new version available

### DIFF
--- a/pkg/core/scrapper.go
+++ b/pkg/core/scrapper.go
@@ -486,7 +486,9 @@ func (s *Scrapper) store(data *plugin.Plugin) error {
 		return err
 	}
 
-	log.Info().Str("moduleName", data.Name).Str("latestVersion", data.LatestVersion).Msg("Updated")
+	if prev.LatestVersion != data.LatestVersion {
+		log.Info().Str("moduleName", data.Name).Str("latestVersion", data.LatestVersion).Msg("Updated")
+	}
 
 	return nil
 }


### PR DESCRIPTION
With the latest PR, we are getting a lot of Updated notification for plugins. As we don't care about updated stars, this PR aims to notify Pilot team only when there is a new version available.