### PR TITLE
feat: add kubernetes snippet generation

### DIFF
--- a/pkg/core/scrapper.go
+++ b/pkg/core/scrapper.go
@@ -603,9 +603,28 @@ func createMiddlewareSnippets(repository *github.Repository, testData map[string
 		return nil, fmt.Errorf("failed to marshall (YAML): %w", err)
 	}
 
+	k8s := map[string]interface{}{
+		"apiVersion": "traefik.containo.us/v1alpha1",
+		"kind":       "Middleware",
+		"metadata": map[string]interface{}{
+			"name":      "my-" + repository.GetName(),
+			"namespace": "my-namespace",
+		},
+		"spec": map[string]interface{}{
+			"plugin": map[string]interface{}{
+				repository.GetName(): testData,
+			},
+		},
+	}
+	k8sSnip, err := yaml.Marshal(k8s)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshall (YAML): %w", err)
+	}
+
 	return map[string]interface{}{
 		"toml": string(tomlSnip),
 		"yaml": string(yamlSnip),
+		"k8s":  string(k8sSnip),
 	}, nil
 }
 

--- a/pkg/core/scrapper_test.go
+++ b/pkg/core/scrapper_test.go
@@ -193,6 +193,17 @@ func Test_createMiddlewareSnippets(t *testing.T) {
                     Headers:
                         Foo: Bar
 `,
+		"k8s": `apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+    name: my-plugintest
+    namespace: my-namespace
+spec:
+    plugin:
+        plugintest:
+            Headers:
+                Foo: Bar
+`,
 	}
 
 	assert.Equal(t, expected, snippets)


### PR DESCRIPTION
### Description

This PR adds k8s snippets for middleware plugins to be displayed in the new Plugin Catalog.

Fixes https://github.com/traefik/pilot/issues/145

Co-authored-by:  Jean-Baptiste Doumenjou <jean-baptiste.doumenjou@traefik.io>