### PR TITLE
fix: blacklist github.com/FinalCAD/TraefikGrpcWebPlugin plugin

### DIFF
--- a/pkg/core/scrapper.go
+++ b/pkg/core/scrapper.go
@@ -89,8 +89,9 @@ func NewScrapper(gh *github.Client, gp *goproxy.Client, pgClient pluginClient, s
 
 		// TODO improve blacklist storage
 		blacklist: map[string]struct{}{
-			"containous/plugintestxxx":     {},
-			"esenac/traefik-custom-router": {}, // The repo doesn't allow issues https://github.com/esenac/traefik-custom-router
+			"containous/plugintestxxx":      {},
+			"esenac/traefik-custom-router":  {}, // The repo doesn't allow issues https://github.com/esenac/traefik-custom-router
+			"FinalCAD/TraefikGrpcWebPlugin": {}, // The repo crash piceus.
 		},
 		skipNewCall: map[string]struct{}{
 			"github.com/negasus/traefik-plugin-ip2location": {},


### PR DESCRIPTION
### Description

Since few hours piceus is crashing on production. I'm suspecting the issue come from https://github.com/FinalCAD/TraefikGrpcWebPlugin. I'm blacklist the plugin for now to avoid to have the job crashing in loop

https://containous.slack.com/archives/C02P6HMCZV3/p1703003342716239

