### PR TITLE
chore: upgrade go lang and linter

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -27,14 +27,14 @@ global_job_config:
       # so it's not possible to use sem-version.
       # - sem-version go 1.14
       - curl -sSfL https://raw.githubusercontent.com/ldez/semgo/master/godownloader.sh | sudo sh -s -- -b "/usr/local/bin"
-      - sudo semgo go1.21
+      - sudo semgo go1.22
       - export "GOPATH=$(go env GOPATH)"
       - export "SEMAPHORE_GIT_DIR=${GOPATH}/src/github.com/traefik/${SEMAPHORE_PROJECT_NAME}"
       - export "PATH=${GOPATH}/bin:${PATH}"
       - mkdir -vp "${SEMAPHORE_GIT_DIR}" "${GOPATH}/bin"
       - export GOPROXY=https://gomod.traefiklabs.tech,https://proxy.golang.org,direct
       - cat /home/semaphore/datas/traefiker-keyfile.json | docker login -u _json_key --password-stdin https://gcr.io
-      - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOPATH}/bin" v1.55.2
+      - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOPATH}/bin" v1.56.2
       - curl -sfL https://gist.githubusercontent.com/traefiker/6d7ac019c11d011e4f131bb2cca8900e/raw/goreleaser.sh | bash -s -- -b "${GOPATH}/bin"
       - checkout
       - cache restore "mod-${SEMAPHORE_PROJECT_NAME}-${SEMAPHORE_GIT_BRANCH}-$(checksum go.mod),mod-${SEMAPHORE_PROJECT_NAME}-$(checksum go.mod),mod-${SEMAPHORE_PROJECT_NAME}"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/traefik/piceus
 
-go 1.21
+go 1.22
 
 require (
 	github.com/ettle/strcase v0.2.0

--- a/pkg/core/scrapper.go
+++ b/pkg/core/scrapper.go
@@ -415,8 +415,9 @@ func (s *Scrapper) getLatestTag(ctx context.Context, repository *github.Reposito
 	}
 
 	if len(tags) == 0 {
-		span.RecordError(fmt.Errorf("missing tag/version"))
-		return "", errors.New("missing tag/version")
+		err := errors.New("missing tag/version")
+		span.RecordError(err)
+		return "", err
 	}
 
 	return tags[0], nil
@@ -441,8 +442,9 @@ func (s *Scrapper) getVersions(ctx context.Context, repository *github.Repositor
 	}
 
 	if len(versions) == 0 {
-		span.RecordError(fmt.Errorf("missing tag/version"))
-		return nil, errors.New("missing tags/versions")
+		err = errors.New("missing tag/version")
+		span.RecordError(err)
+		return nil, err
 	}
 
 	return versions, err

--- a/pkg/core/scrapper_test.go
+++ b/pkg/core/scrapper_test.go
@@ -144,7 +144,7 @@ func TestScrapper_store(t *testing.T) {
 		{
 			desc: "create",
 			pgClient: &mockPluginClient{
-				getByName: func(name string) (*plugin.Plugin, error) {
+				getByName: func(_ string) (*plugin.Plugin, error) {
 					return nil, &plugin.APIError{StatusCode: http.StatusNotFound, Message: "not found"}
 				},
 			},
@@ -152,7 +152,7 @@ func TestScrapper_store(t *testing.T) {
 		{
 			desc: "update",
 			pgClient: &mockPluginClient{
-				getByName: func(name string) (*plugin.Plugin, error) {
+				getByName: func(_ string) (*plugin.Plugin, error) {
 					return &plugin.Plugin{ID: "aaaa", Name: "test"}, nil
 				},
 			},

--- a/pkg/core/wasm.go
+++ b/pkg/core/wasm.go
@@ -168,7 +168,7 @@ func getWasmPath(manifest Manifest) (string, error) {
 	}
 
 	if !filepath.IsLocal(wasmPath) {
-		return "", fmt.Errorf("wasmPath must be a local path")
+		return "", errors.New("wasmPath must be a local path")
 	}
 
 	return wasmPath, nil

--- a/pkg/core/yaegi.go
+++ b/pkg/core/yaegi.go
@@ -134,7 +134,7 @@ func (s *Scrapper) getModuleInfo(ctx context.Context, repository *github.Reposit
 func yaegiMiddlewareCheck(goPath string, manifest Manifest, skipNew bool) error {
 	middlewareName := "test"
 
-	next := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {})
+	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
 	timeout := 10 * time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)


### PR DESCRIPTION
# Description

1. Upgrade go lang to 1.22
2. Upgrade linter to v1.56.2
