### PR TITLE
fix: remove language:Go from search query

### DIFF
--- a/pkg/core/scrapper.go
+++ b/pkg/core/scrapper.go
@@ -40,7 +40,7 @@ const (
 const (
 	// searchQuery the query used to search plugins on GitHub.
 	// https://help.github.com/en/github/searching-for-information-on-github/searching-for-repositories
-	searchQuery = "topic:traefik-plugin language:Go archived:false is:public"
+	searchQuery = "topic:traefik-plugin archived:false is:public"
 
 	// searchQueryIssues the query used to search issues opened by the bot account.
 	searchQueryIssues = "is:open is:issue is:public author:traefiker"

--- a/pkg/core/scrapper.go
+++ b/pkg/core/scrapper.go
@@ -273,6 +273,11 @@ func (s *Scrapper) process(ctx context.Context, repository *github.Repository) (
 		}
 
 	default:
+		if repository.GetLanguage() != "Go" {
+			log.Info().Str("repo_name", repository.GetFullName()).Msg("Yaegi plugin is not developed in Go")
+			return nil, nil
+		}
+
 		pluginName, versions, err = s.verifyYaegiPlugin(ctx, repository, latestVersion, manifest)
 		if err != nil {
 			span.RecordError(err)


### PR DESCRIPTION
### Description

This Pr removes the `language:Go` from query search

Fixes #57 

Related to: https://github.com/traefik/plugindemowasm/issues/6