### PR TITLE
Fix missing context in wazergo

### DIFF
--- a/pkg/core/wasip.go
+++ b/pkg/core/wasip.go
@@ -11,7 +11,7 @@ import (
 	wazero_wasip1 "github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 )
 
-func instantiate(ctx context.Context, runtime wazero.Runtime, mod wazero.CompiledModule) error {
+func instantiate(ctx context.Context, runtime wazero.Runtime, mod wazero.CompiledModule) (context.Context, error) {
 	extension := imports.DetectSocketsExtension(mod)
 	if extension != nil {
 		hostModule := wazergo_wasip1.NewHostModule(*extension)
@@ -22,20 +22,20 @@ func instantiate(ctx context.Context, runtime wazero.Runtime, mod wazero.Compile
 		var err error
 		ctx, sys, err = builder.Instantiate(ctx, runtime)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		_, err = wazergo.Instantiate(ctx, runtime, hostModule, wazergo_wasip1.WithWASI(sys))
 		if err != nil {
-			return err
+			return nil, err
 		}
 
-		return nil
+		return ctx, nil
 	}
 
 	_, err := wazero_wasip1.Instantiate(ctx, runtime)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+	return ctx, nil
 }

--- a/pkg/core/wasm.go
+++ b/pkg/core/wasm.go
@@ -163,12 +163,12 @@ func checkWasmMiddleware(file *zip.File, manifest Manifest) error {
 		return fmt.Errorf("failed to compile module: %w", err)
 	}
 
-	err = instantiate(ctx, runtime, mod)
+	ctx, err = instantiate(ctx, runtime, mod)
 	if err != nil {
 		return fmt.Errorf("failed to instantiate module wasip1: %w", err)
 	}
 
-	_, err = wasm.NewMiddleware(context.Background(), pluginBytes, handler.GuestConfig(b), handler.Runtime(func(_ context.Context) (wazero.Runtime, error) {
+	_, err = wasm.NewMiddleware(ctx, pluginBytes, handler.GuestConfig(b), handler.Runtime(func(_ context.Context) (wazero.Runtime, error) {
 		return runtime, nil
 	}))
 	if err != nil {


### PR DESCRIPTION
This PR fix the wrong context used in the CreateMiddleware when using wazergo