### PR TITLE
chore: update blacklist

### DIFF
--- a/pkg/core/scrapper.go
+++ b/pkg/core/scrapper.go
@@ -99,6 +99,7 @@ func NewScrapper(gh *github.Client, gp *goproxy.Client, pgClient pluginClient, d
 			"FinalCAD/TraefikGrpcWebPlugin":           {}, // Crash piceus.
 			"deas/teectl":                             {}, // Not a plugin
 			"GDGVIT/securum-exire":                    {}, // Not a plugin
+			"morzan1001/forward_auth_grpc_plugin":     {}, // piceus panic (excluded during fix)
 		},
 		skipNewCall: map[string]struct{}{
 			"github.com/negasus/traefik-plugin-ip2location": {},


### PR DESCRIPTION
## Description

This PR excludes "morzan1001/forward_auth_grpc_plugin" because it crashes Piceus.
It will be allowed again after a fix.