### PR TITLE
Do not require semantic version require `v` prefix

### DIFF
--- a/pkg/core/scrapper.go
+++ b/pkg/core/scrapper.go
@@ -488,7 +488,7 @@ func (s *Scrapper) getTags(ctx context.Context, repository *github.Repository) (
 		return nil, fmt.Errorf("failed to get versions: %w", err)
 	}
 
-	expSemver := regexp.MustCompile(`^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
+	expSemver := regexp.MustCompile(`^(v)?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
 
 	var result []string
 	for _, tag := range tags {


### PR DESCRIPTION
I made a new traefik plugin that had an issue added on the repo https://github.com/libops/captcha-protect/issues/3

The error message was confusing, since `0.0.2` is a semantic version.

```
failed to get the latest tag: invalid tag: 0.0.2 (this tag must be removed, see https://semver.org)
```

Looks like this repo requires `v` on the version, which is not a semantic version. [From semver.org](https://semver.org/#is-v123-a-semantic-version)

> **Is “v1.2.3” a semantic version?**
No, “v1.2.3” is not a semantic version.

This PR makes `v` optional in the version tag.