### PR TITLE
fix: slowdown usage on search API

### DIFF
--- a/pkg/core/scrapper.go
+++ b/pkg/core/scrapper.go
@@ -57,7 +57,7 @@ If you believe there is a problem with the Analyzer or this issue is the result 
 `
 )
 
-const searchThrottling = 25
+const searchThrottling = 4
 
 type pluginClient interface {
 	Create(ctx context.Context, p plugin.Plugin) error


### PR DESCRIPTION
# Motivation

Avoid to be rate-limited on piceus or other usage using the same gh account.