### PR TITLE
chore(github): slowdown usage to avoid hitting secondary rate limit

### DIFF
--- a/pkg/core/adaptive_rate_limiter.go
+++ b/pkg/core/adaptive_rate_limiter.go
@@ -20,8 +20,8 @@ type AdaptiveRateLimiter struct {
 func NewAdaptiveRateLimiter() *AdaptiveRateLimiter {
 	return &AdaptiveRateLimiter{
 		remaining:    30, // GitHub search API default limit
-		resetTime:    time.Now().Add(time.Minute),
-		safetyBuffer: 25, // Keep 25 requests as safety buffer
+		resetTime:    time.Now().Add(2 * time.Minute),
+		safetyBuffer: 27, // Keep 27 requests as safety buffer
 	}
 }
 

--- a/pkg/core/adaptive_rate_limiter_test.go
+++ b/pkg/core/adaptive_rate_limiter_test.go
@@ -16,7 +16,7 @@ func TestNewAdaptiveRateLimiter(t *testing.T) {
 
 	require.NotNil(t, rl)
 	assert.Equal(t, 30, rl.remaining)
-	assert.Equal(t, 25, rl.safetyBuffer)
+	assert.Equal(t, 27, rl.safetyBuffer)
 	assert.True(t, rl.resetTime.After(time.Now()))
 	assert.True(t, rl.resetTime.Before(time.Now().Add(2*time.Minute)))
 }

--- a/pkg/core/scrapper.go
+++ b/pkg/core/scrapper.go
@@ -178,6 +178,9 @@ func (s *Scrapper) Run(ctx context.Context) error {
 			span.RecordError(err)
 			logger.Error().Err(err).Msg("Failed to store plugin")
 		}
+		// We need to avoid getting rate limited
+		// With 500 plugins * 15s =~ 2h
+		time.Sleep(15 * time.Second)
 	}
 
 	return nil
@@ -224,6 +227,8 @@ func (s *Scrapper) searchReposWithExistingIssue(ctx context.Context) ([]string, 
 			}
 
 			opts.Page = resp.NextPage
+			// We need to avoid getting rate limited
+			time.Sleep(time.Minute)
 		}
 	}
 


### PR DESCRIPTION
# Motivation

Avoid to be rate-limited on piceus or other usage using the same gh account.