### PR TITLE
fix: add timeout to WASM plugin verification to prevent indefinite blocking

### DIFF
--- a/pkg/core/scrapper.go
+++ b/pkg/core/scrapper.go
@@ -101,7 +101,6 @@ func NewScrapper(gh *github.Client, gp *goproxy.Client, pgClient pluginClient, d
 			"thubolt/geoblock":                          {}, // Doesn't allow issues
 			"tmpim/tmpauth-traefik":                     {}, // Doesn't allow issues
 			"alexdelprete/traefik-oidc-relying-party":   {},
-			"jannschu/maintenance-response":             {}, // Block piceus
 			"FinalCAD/TraefikGrpcWebPlugin":             {}, // Crash piceus.
 			"deas/teectl":                               {}, // Not a plugin
 			"GDGVIT/securum-exire":                      {}, // Not a plugin

--- a/pkg/core/wasm.go
+++ b/pkg/core/wasm.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"path"
 	"path/filepath"
+	"time"
 
 	"github.com/google/go-github/v57/github"
 	"github.com/http-wasm/http-wasm-host-go/handler"
@@ -19,6 +20,8 @@ import (
 )
 
 const wasmFile = "plugin.wasm"
+
+const wasmCheckTimeout = 60 * time.Second
 
 func (s *Scrapper) verifyWASMPlugin(ctx context.Context, repository *github.Repository, latestVersion string, manifest Manifest) (string, []string, error) {
 	pluginName := path.Join("github.com", repository.GetFullName())
@@ -121,7 +124,9 @@ func (s *Scrapper) verifyZip(ctx context.Context, owner, repo string, assetID in
 
 	switch manifest.Type {
 	case typeMiddleware:
-		err = checkWasmMiddleware(wasmPluginFile, manifest)
+		err = runWithTimeout(wasmCheckTimeout, func() error {
+			return checkWasmMiddleware(ctx, wasmPluginFile, manifest)
+		})
 		if err != nil {
 			return fmt.Errorf("failed to check wasm middleware: %w", err)
 		}
@@ -137,7 +142,7 @@ func (s *Scrapper) verifyZip(ctx context.Context, owner, repo string, assetID in
 	return nil
 }
 
-func checkWasmMiddleware(file *zip.File, manifest Manifest) error {
+func checkWasmMiddleware(ctx context.Context, file *zip.File, manifest Manifest) error {
 	readCloser, err := file.Open()
 	if err != nil {
 		return fmt.Errorf("failed to open wasm file: %w", err)
@@ -153,7 +158,6 @@ func checkWasmMiddleware(file *zip.File, manifest Manifest) error {
 		return fmt.Errorf("failed to marshal test data: %w", err)
 	}
 
-	ctx := context.Background()
 	runtime := host.NewRuntime(wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfig()))
 
 	mod, err := runtime.CompileModule(ctx, pluginBytes)
@@ -174,6 +178,20 @@ func checkWasmMiddleware(file *zip.File, manifest Manifest) error {
 	}
 
 	return nil
+}
+
+func runWithTimeout(timeout time.Duration, fn func() error) error {
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- fn()
+	}()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-time.After(timeout):
+		return fmt.Errorf("timed out after %s", timeout)
+	}
 }
 
 func getWasmPath(manifest Manifest) (string, error) {

--- a/pkg/core/wasm_test.go
+++ b/pkg/core/wasm_test.go
@@ -1,0 +1,61 @@
+package core
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunWithTimeout(t *testing.T) {
+	testCases := []struct {
+		desc        string
+		timeout     time.Duration
+		fn          func() error
+		expectError bool
+		errContains string
+	}{
+		{
+			desc:    "function completes before timeout",
+			timeout: time.Second,
+			fn: func() error {
+				return nil
+			},
+		},
+		{
+			desc:    "function returns error before timeout",
+			timeout: time.Second,
+			fn: func() error {
+				return errors.New("plugin error")
+			},
+			expectError: true,
+			errContains: "plugin error",
+		},
+		{
+			desc:    "function blocks and gets timed out",
+			timeout: 100 * time.Millisecond,
+			fn: func() error {
+				select {}
+			},
+			expectError: true,
+			errContains: "timed out after",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			err := runWithTimeout(test.timeout, test.fn)
+
+			if test.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), test.errContains)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

  - Add a `runWithTimeout` helper that wraps any function with a hard timeout via goroutine + `select`, since wazero does not respect
  `context.Context` deadlines during module instantiation
  - Wrap `checkWasmMiddleware` with a 10s timeout (aligned with the existing Yaegi verification timeout), preventing piceus from hanging
   indefinitely when a WASM plugin makes blocking network calls during initialization
  - Pass `context.Context` into `checkWasmMiddleware` for future-proofing, even though wazero currently ignores it
  
  Fixes https://github.com/traefik/piceus/issues/146