### PR TITLE
ci: :rocket: migrate to github-hosted runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   lint:
-    runs-on: 'shipfox-2vcpu-ubuntu-2404'
+    runs-on: 'ubuntu-latest'
     if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.draft }}
     env:
       # renovate: datasource=github-tags depName=golangci/golangci-lint versioning=loose
@@ -46,7 +46,7 @@ jobs:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
 
   test:
-    runs-on: 'shipfox-2vcpu-ubuntu-2404'
+    runs-on: 'ubuntu-latest'
     if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.draft }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -64,7 +64,7 @@ jobs:
         include:
           - arch: amd64
           - arch: arm64
-    runs-on: ${{ matrix.arch == 'amd64' && 'shipfox-2vcpu-ubuntu-2404' || 'shipfox-2vcpu-ubuntu-2404-arm' }}
+    runs-on: ${{ matrix.arch == 'amd64' && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     permissions:
       contents: read

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,7 +112,7 @@ jobs:
 
   push-manifest:
     if: ${{ github.event_name == 'push' || startsWith(github.ref, 'refs/tags/') }}
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-slim'
     needs: [ build ]
     permissions:
       contents: read


### PR DESCRIPTION
# Motivation

Shipfox (the CI runner provider used by this workflow) is shutting down.
This PR migrates the workflow to GitHub-hosted runners:

- `ubuntu-latest` for x64 jobs
- `ubuntu-24.04-arm` for arm64 jobs

No change in CI behavior is expected.
